### PR TITLE
[FEAT] #29: Manu 재고 관리 기능 구현

### DIFF
--- a/msa-common/src/main/java/com/example/common/exception/BusinessException.java
+++ b/msa-common/src/main/java/com/example/common/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.example.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+	private final CommonCode code;
+	private final String detail;
+
+	public BusinessException(CommonCode code) {
+		super(code.getMessage());
+		this.code = code;
+		this.detail = null;
+	}
+	public BusinessException(CommonCode code, String detail) {
+		super(code.getMessage());
+		this.code = code;
+		this.detail = detail;
+	}
+}

--- a/msa-common/src/main/java/com/example/common/exception/CommonCode.java
+++ b/msa-common/src/main/java/com/example/common/exception/CommonCode.java
@@ -28,7 +28,13 @@ public enum CommonCode {
     STORE_DELETED(HttpStatus.GONE, 4201, "지워진 상점입니다."),
 
     // ✅ 서버 오류
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 오류"),
+
+    // ✅ 재고 관련 오류
+    INVENTORY_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "재고 정보를 찾을 수 없습니다."),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, 4301, "재고가 부족합니다."),
+    RESERVED_NOT_ENOUGH(HttpStatus.BAD_REQUEST, 4302, "예약 수량이 부족합니다."),
+    CONCURRENCY_CONFLICT(HttpStatus.CONFLICT, 4303, "동시에 처리 요청이 충돌했습니다. 다시 시도해주세요.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/msa-store-service/src/main/java/com/example/storeservice/controller/MenuInventoryController.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/controller/MenuInventoryController.java
@@ -1,0 +1,82 @@
+package com.example.storeservice.controller;
+
+import java.util.UUID;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.common.dto.ApiResponse;
+import com.example.storeservice.service.MenuInventoryService;
+
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/internal/inventory")
+@RequiredArgsConstructor
+@Validated
+public class MenuInventoryController {
+
+	private final MenuInventoryService inventoryService;
+
+	@PostMapping("/{menuId}/init")
+	public ApiResponse<Void> init(@PathVariable UUID menuId,
+		@RequestParam @Min(1) int initialQty,
+		@RequestParam(defaultValue = "false") boolean infinite) {
+
+		inventoryService.initInventory(menuId, initialQty, infinite);
+		return ApiResponse.success();
+	}
+
+	@GetMapping("/{menuId}/available")
+	public ApiResponse<Integer> getAvailable(@PathVariable UUID menuId) {
+		int qty = inventoryService.getAvailableQty(menuId);
+		return ApiResponse.success(qty);
+	}
+
+	@GetMapping("/{menuId}/sold-out")
+	public ApiResponse<Boolean> isSoldOut(@PathVariable UUID menuId) {
+		boolean soldOut = inventoryService.isSoldOut(menuId);
+		return ApiResponse.success(soldOut);
+	}
+
+	@PostMapping("/{menuId}/reserve")
+	public ApiResponse<Void> reserve(@PathVariable UUID menuId,
+		@RequestParam @Min(1) int qty) {
+		inventoryService.reserve(menuId, qty);
+		return ApiResponse.success();
+	}
+
+	@PostMapping("/{menuId}/confirm")
+	public ApiResponse<Void> confirm(@PathVariable UUID menuId,
+		@RequestParam @Min(1) int qty) {
+		inventoryService.confirm(menuId, qty);
+		return ApiResponse.success();
+	}
+
+	@PostMapping("/{menuId}/release")
+	public ApiResponse<Void> release(@PathVariable UUID menuId,
+		@RequestParam @Min(1) int qty) {
+		inventoryService.release(menuId, qty);
+		return ApiResponse.success();
+	}
+
+	@PostMapping("/{menuId}/adjust")
+	public ApiResponse<Void> adjust(@PathVariable UUID menuId,
+		@RequestParam @Min(0) int qty) {
+		inventoryService.adjust(menuId, qty);
+		return ApiResponse.success();
+	}
+
+	@PostMapping("/{menuId}/infinite")
+	public ApiResponse<Void> setInfinite(@PathVariable UUID menuId,
+		@RequestParam("value") boolean infinite) {
+		inventoryService.setInfinite(menuId, infinite);
+		return ApiResponse.success();
+	}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/controller/ReviewController.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/controller/ReviewController.java
@@ -1,6 +1,6 @@
 package com.example.storeservice.controller;
 
-import com.example.common.ApiResponse;
+import com.example.common.dto.ApiResponse;
 import com.example.storeservice.dto.CreateReviewDto;
 import com.example.storeservice.dto.ReviewDto;
 import com.example.storeservice.entity.Review;

--- a/msa-store-service/src/main/java/com/example/storeservice/entity/MenuInventory.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/entity/MenuInventory.java
@@ -1,0 +1,52 @@
+package com.example.storeservice.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "p_menu_inventory")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuInventory {
+
+	@Id
+	@Column(name = "menu_id", nullable = false)
+	private UUID menuId;
+
+	@OneToOne
+	@MapsId
+	@JoinColumn(name = "menu_id")
+	private Menu menu;
+
+	@Column(name = "is_infinite_stock", nullable = false)
+	private boolean isInfiniteStock;
+
+	@Column(name = "available_qty", nullable = false)
+	private int availableQty;
+
+	@Column(name = "reserved_qty", nullable = false)
+	private int reservedQty;
+
+	@Version
+	@Column(name = "version", nullable = false)
+	private Long version;
+
+	public boolean isSoldOut() {
+		if (Boolean.TRUE.equals(isInfiniteStock)) return false;
+		return reservedQty <= 0;
+	}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/entity/MenuInventory.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/entity/MenuInventory.java
@@ -46,7 +46,7 @@ public class MenuInventory {
 	private Long version;
 
 	public boolean isSoldOut() {
-		if (Boolean.TRUE.equals(isInfiniteStock)) return false;
-		return reservedQty <= 0;
+		if (isInfiniteStock) return false;
+		return availableQty <= 0;
 	}
 }

--- a/msa-store-service/src/main/java/com/example/storeservice/exception/InvalidQuantityException.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/exception/InvalidQuantityException.java
@@ -1,0 +1,10 @@
+package com.example.storeservice.exception;
+
+import com.example.common.exception.BusinessException;
+import com.example.common.exception.CommonCode;
+
+public class InvalidQuantityException extends BusinessException {
+	public InvalidQuantityException() {
+		super(CommonCode.INVENTORY_NOT_FOUND);
+	}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/exception/InvalidQuantityException.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/exception/InvalidQuantityException.java
@@ -4,7 +4,7 @@ import com.example.common.exception.BusinessException;
 import com.example.common.exception.CommonCode;
 
 public class InvalidQuantityException extends BusinessException {
-	public InvalidQuantityException() {
-		super(CommonCode.INVENTORY_NOT_FOUND);
+	public InvalidQuantityException(String detail) {
+		super(CommonCode.BAD_REQUEST, detail);
 	}
 }

--- a/msa-store-service/src/main/java/com/example/storeservice/exception/InventoryNotFoundException.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/exception/InventoryNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.storeservice.exception;
+
+import com.example.common.exception.BusinessException;
+import com.example.common.exception.CommonCode;
+
+public class InventoryNotFoundException extends BusinessException {
+	public InventoryNotFoundException() {super(CommonCode.INVENTORY_NOT_FOUND);}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/exception/OutOfStockException.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/exception/OutOfStockException.java
@@ -1,0 +1,10 @@
+package com.example.storeservice.exception;
+
+import com.example.common.exception.BusinessException;
+import com.example.common.exception.CommonCode;
+
+public class OutOfStockException extends BusinessException {
+	public OutOfStockException() {
+		super(CommonCode.OUT_OF_STOCK);
+	}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/exception/ReservedNoEnoughException.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/exception/ReservedNoEnoughException.java
@@ -1,0 +1,10 @@
+package com.example.storeservice.exception;
+
+import com.example.common.exception.BusinessException;
+import com.example.common.exception.CommonCode;
+
+public class ReservedNoEnoughException extends BusinessException {
+	public ReservedNoEnoughException() {
+		super(CommonCode.RESERVED_NOT_ENOUGH);
+	}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/exception/ReservedNotEnoughException.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/exception/ReservedNotEnoughException.java
@@ -3,8 +3,8 @@ package com.example.storeservice.exception;
 import com.example.common.exception.BusinessException;
 import com.example.common.exception.CommonCode;
 
-public class ReservedNoEnoughException extends BusinessException {
-	public ReservedNoEnoughException() {
+public class ReservedNotEnoughException extends BusinessException {
+	public ReservedNotEnoughException() {
 		super(CommonCode.RESERVED_NOT_ENOUGH);
 	}
 }

--- a/msa-store-service/src/main/java/com/example/storeservice/repository/MenuInventoryRepository.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/repository/MenuInventoryRepository.java
@@ -1,0 +1,10 @@
+package com.example.storeservice.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.storeservice.entity.MenuInventory;
+
+public interface MenuInventoryRepository extends JpaRepository<MenuInventory, UUID> {
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/repository/MenuRepository.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/repository/MenuRepository.java
@@ -14,5 +14,5 @@ public interface MenuRepository extends JpaRepository<Menu, UUID> {
     List<Menu> findAllByStore_StoreIdAndIsDeletedFalse(UUID storeId);
     Optional<Menu> findByMenuIdAndIsDeletedFalse(UUID menuId);
 
-
+	UUID menuId(UUID menuId);
 }

--- a/msa-store-service/src/main/java/com/example/storeservice/service/MenuInventoryService.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/service/MenuInventoryService.java
@@ -1,0 +1,24 @@
+package com.example.storeservice.service;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.storeservice.repository.MenuInventoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MenuInventoryService {
+
+	private final MenuInventoryRepository menuInventoryRepository;
+
+	@Transactional
+	public int getAvailableQty(UUID menuId) {
+		var inventory = menuInventoryRepository.findById(menuId)
+			.orElse
+	}
+}

--- a/msa-store-service/src/main/java/com/example/storeservice/service/MenuInventoryService.java
+++ b/msa-store-service/src/main/java/com/example/storeservice/service/MenuInventoryService.java
@@ -1,24 +1,166 @@
 package com.example.storeservice.service;
 
+import static java.awt.SystemColor.*;
+
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
+import org.hibernate.StaleObjectStateException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import com.example.storeservice.entity.Menu;
+import com.example.storeservice.entity.MenuInventory;
+import com.example.storeservice.exception.InvalidQuantityException;
+import com.example.storeservice.exception.InventoryNotFoundException;
+import com.example.storeservice.exception.OutOfStockException;
+import com.example.storeservice.exception.ReservedNotEnoughException;
 import com.example.storeservice.repository.MenuInventoryRepository;
+import com.example.storeservice.repository.MenuRepository;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class MenuInventoryService {
 
-	private final MenuInventoryRepository menuInventoryRepository;
+	private final MenuInventoryRepository inventoryRepo;
+	private final MenuRepository menuRepo;
+	private final PlatformTransactionManager transactionManager;
 
-	@Transactional
+	private static final int MAX_ATTEMPTS = 5;
+	private static final long BASE_BACKOFF_MS = 15;
+	private TransactionTemplate transactionTemplate;
+
+	@PostConstruct
+	void init() {
+		this.transactionTemplate = new TransactionTemplate(transactionManager);
+	}
+
+	@Transactional(readOnly = true)
 	public int getAvailableQty(UUID menuId) {
-		var inventory = menuInventoryRepository.findById(menuId)
-			.orElse
+		MenuInventory inventory = inventoryRepo.findById(menuId)
+			.orElseThrow(InventoryNotFoundException::new);
+		return inventory.getAvailableQty();
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isSoldOut(UUID menuId) {
+		MenuInventory inventory = inventoryRepo.findById(menuId)
+			.orElseThrow(InventoryNotFoundException::new);
+		if (inventory.isInfiniteStock()) return false;
+		return inventory.getAvailableQty() <= 0;
+	}
+
+	public void initInventory(UUID menuId, int initialQty, boolean infinite) {
+		if (inventoryRepo.existsById(menuId)) {
+			return;
+		}
+
+	  Menu menu = menuRepo.findById(menuId).orElseThrow(InventoryNotFoundException::new);
+
+		if (initialQty <= 0) throw new InvalidQuantityException("초기 수량은 1개 이상 설정 가능합니다.");
+
+		MenuInventory inventory = new MenuInventory(
+			menuId,
+			menu,
+			infinite,
+			infinite ? 0 : initialQty,
+			0,
+			null
+		);
+		inventoryRepo.save(inventory);
+	}
+
+	public void reserve(UUID menuId, int qty) {
+		validateQty(qty);
+
+		runWithRetry(() -> transactionTemplate.executeWithoutResult(status -> {
+			MenuInventory inv = inventoryRepo.findById(menuId).orElseThrow(InventoryNotFoundException::new);
+			if (inv.isInfiniteStock()) return;
+			if (inv.getAvailableQty() < qty) throw new OutOfStockException();
+
+			inv.setAvailableQty(inv.getAvailableQty() - qty);
+			inv.setReservedQty(inv.getReservedQty() + qty);
+		}));
+	}
+
+	public void confirm(UUID menuId, int qty) {
+		validateQty(qty);
+
+		runWithRetry(() -> transactionTemplate.executeWithoutResult(status -> {
+			MenuInventory inv = inventoryRepo.findById(menuId).orElseThrow(InventoryNotFoundException::new);
+			if (inv.isInfiniteStock()) return;
+			if (inv.getReservedQty() < qty) throw new ReservedNotEnoughException();
+
+			inv.setReservedQty(inv.getReservedQty() - qty);
+		}));
+	}
+
+	public void release(UUID menuId, int qty) {
+		validateQty(qty);
+
+		runWithRetry(() -> transactionTemplate.executeWithoutResult(status -> {
+			MenuInventory inv = inventoryRepo.findById(menuId).orElseThrow(InventoryNotFoundException::new);
+
+			if (inv.isInfiniteStock()) return;
+			if (inv.getReservedQty() < qty) throw new ReservedNotEnoughException();
+
+			inv.setReservedQty(inv.getReservedQty() - qty);
+			inv.setAvailableQty(inv.getAvailableQty() + qty);
+		}));
+	}
+
+	public void adjust(UUID menuId, int newAvailableQty) {
+		if (newAvailableQty < 0) throw new InvalidQuantityException("주문 가능 수량은 1 이상이어야 가능합니다.");
+
+		runWithRetry(() -> transactionTemplate.executeWithoutResult(status -> {
+			MenuInventory inv = inventoryRepo.findById(menuId).orElseThrow(InventoryNotFoundException::new);
+			if (inv.isInfiniteStock()) return;
+
+			inv.setAvailableQty(newAvailableQty);
+		}));
+	}
+
+	public void setInfinite(UUID menuId, boolean infinite) {
+		runWithRetry(() -> transactionTemplate.executeWithoutResult(status -> {
+			MenuInventory inv = inventoryRepo.findById(menuId).orElseThrow(InventoryNotFoundException::new);
+			inv.setInfiniteStock(infinite);
+			if (infinite) {
+				inv.setAvailableQty(0);
+				inv.setReservedQty(0);
+			}
+		}));
+	}
+
+	private void runWithRetry(Runnable action) {
+		int tries = 0;
+		while (true) {
+			try {
+				action.run();
+				return;
+			} catch (OptimisticLockException
+					 | ObjectOptimisticLockingFailureException
+					 | StaleObjectStateException e) {
+				tries++;
+				if (tries >= MAX_ATTEMPTS) throw e;
+				sleepBackoff(tries);
+			}
+		}
+	}
+
+	private void sleepBackoff(int attempt) {
+		long jitter = ThreadLocalRandom.current().nextLong(0, 8);
+		long backoff = (long)(BASE_BACKOFF_MS * Math.pow(2, attempt - 1)) + jitter;
+		try {Thread.sleep(backoff);} catch (InterruptedException ie) {Thread.currentThread().interrupt();}
+	}
+
+	private void validateQty(int qty) {
+		if (qty <= 0) throw new InvalidQuantityException("qty must be > 0");
 	}
 }


### PR DESCRIPTION
### Overview

- menu 재고 관리 기능 추가

### Change Log

- p_menu_inventory 테이블 추가
- 낙관적 락 추가
- 재고 관리 위해 availableQty, reserveQty 두 컬럼으로 주문 가능 재고와 현재 주문/결제 진행 중인 재고 추적 관리

### To Reviewer

- 리뷰어 참고사항

### Issue Tags

- Closed | Fixed : #
- see also: #29 

### Reviewer

- 리뷰어

### Assignee

- 담당자
